### PR TITLE
mysqld fails to start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,9 +31,6 @@ ENV MYSQL_CLUSTER_DATA ${MYSQL_CLUSTER_HOME}/data
 ENV MYSQL_CLUSTER_LOG /var/lib/mysql-cluster
 ENV MYSQL_CLUSTER_CONFIG /etc/mysql-cluster.ini
 
-VOLUME ${MYSQL_CLUSTER_LOG}
-VOLUME ${MYSQL_CLUSTER_DATA}
-
 RUN cd /var/tmp \
     && curl --silent -OL http://dev.mysql.com/get/Downloads/MySQL-Cluster-${MYSQL_CLUSTER_VERSION}/${MYSQL_CLUSTER_ARCHIVE} \
     && mkdir -p ${MYSQL_CLUSTER_HOME} \
@@ -46,6 +43,9 @@ RUN cd /var/tmp \
 
 RUN cd ${MYSQL_CLUSTER_HOME} \
     && ./scripts/mysql_install_db --user=${MYSQL_USER}
+
+VOLUME ${MYSQL_CLUSTER_LOG}
+VOLUME ${MYSQL_CLUSTER_DATA}
 
 
 ####################################################
@@ -64,4 +64,3 @@ ADD run.sh /run.sh
 RUN chmod +x /run.sh
 ENTRYPOINT ["/run.sh"]
 CMD ["ndb_mgm"]
-

--- a/run.sh
+++ b/run.sh
@@ -34,7 +34,7 @@ elif [ $1 == "ndb_mgmd" ]; then
     ${MYSQL_CLUSTER_BIN}/ndb_mgmd --nodaemon ${RELOAD} ${INITIAL} -f ${MYSQL_CLUSTER_CONFIG} # --no-nodeid-checks --ndb-nodeid=1
 elif [ $1 == "mysqld" ]; then
     echo "Starting mysqld_safe..."
-    ${MYSQL_CLUSTER_BIN}/mysqld_safe --nodaemon --ndbcluster --ledir=${MYSQL_CLUSTER_BIN} --ndb-connectstring=${MYSQL_MANAGEMENT_SERVER} # --skip-grant-tables
+    ${MYSQL_CLUSTER_BIN}/mysqld_safe --ndbcluster --ledir=${MYSQL_CLUSTER_BIN} --ndb-connectstring=${MYSQL_MANAGEMENT_SERVER} # --skip-grant-tables
 else
     echo "Starting ndb_mgm..."
     ${MYSQL_CLUSTER_BIN}/ndb_mgm ${MYSQL_MANAGEMENT_SERVER}


### PR DESCRIPTION
Hello, and thanks for putting this code on GitHub, it's been really helpful to me!

I ran into a couple problems getting `mysqld` running, and have made a couple changes.

The first is simply moving the VOLUME declarations in the Dockerfile until later in the build process because the chown wasn't working.  [Here's a StackOverflow explaining that problem.](http://stackoverflow.com/questions/26145351/why-doesnt-chown-work-in-dockerfile)

```
Step 19 : RUN ls -la ${MYSQL_CLUSTER_HOME}
 ---> Running in 2c887267e6ab
total 180
drwxr-sr-x 13 root mysql   4096 Mar 12 22:55 .
drwxrwsr-x 12 root staff   4096 Mar 12 22:53 ..
-rw-r--r--  1 root mysql  17987 Feb 18 14:21 COPYING
-rw-r--r--  1 root mysql 102494 Feb 18 14:21 INSTALL-BINARY
-rw-r--r--  1 root mysql   2496 Feb 18 14:21 README
drwxr-sr-x  2 root mysql   4096 Mar 12 22:55 bin
drwxr-xr-x  2 root staff   4096 Mar 12 23:04 data
drwxr-sr-x  2 root mysql   4096 Mar 12 22:55 docs
drwxr-sr-x  4 root mysql   4096 Mar 12 22:55 include
drwxr-sr-x  3 root mysql   4096 Mar 12 22:55 lib
drwxr-sr-x  4 root mysql   4096 Mar 12 22:55 man
drwxr-sr-x 10 root mysql   4096 Mar 12 22:55 mysql-test
drwxr-sr-x  2 root mysql   4096 Mar 12 22:55 scripts
drwxr-sr-x 32 root mysql   4096 Mar 12 22:55 share
drwxr-sr-x  4 root mysql   4096 Mar 12 22:55 sql-bench
drwxr-sr-x  2 root mysql   4096 Mar 12 22:55 support-files
```

The second was removing the `--nodaemon` flag from the `mysqld_safe` command because it is not a valid flag for `mysqld` and it was causing it to fail upon startup (`mysqld_safe` always runs in the foreground):

```
2015-03-12 23:20:35 175 [ERROR] /usr/local/mysql/bin/mysqld: unknown option '--nodaemon'
2015-03-12 23:20:35 175 [ERROR] Aborting
```

Thanks again!